### PR TITLE
remove lower bounds on Einsum and Sugar

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-Einsum 0.1
-DataStructures 0.5.1
-Sugar 0.2.0
+Einsum
+DataStructures 0.5.2
+Sugar


### PR DESCRIPTION
your tests seem to pass even with those packages pinned to their earliest releases
DataStructures, on the other hand, doesn't load on julia 0.6 before v0.5.2